### PR TITLE
Fixes for a first time user running the bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cineman",
-  "version": "0.2",
+  "version": "0.2.0",
   "description": "Discord bot that allows users to search for movies, add them to a queue, and vote on their favorites.",
   "main": "src/bot.js",
   "dependencies": {

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ if ! [ -f "$AUTH" ]; then
     read omdb
     echo 'Discord bot key:'
     read discord
-    printf '{\n  "omdb":"'$omdb'",\n  "discord":"'$discord'"\n}' > ./conf/auth.json
+    printf '{\n  "omdb":"'$omdb'",\n  "discord":"'$discord'"\n}' > ./auth.json
 fi
 
 # Checks architecture before starting Docker
@@ -17,8 +17,8 @@ if [[ "$ARCH" == "x86"* ]]; then
 elif [[ "$ARCH" == "arm"* ]]; then
     docker-compose -f docker-compose-arm.yml up -d
 else
-    echo 'Unsupported architecture.'
-    exit 1
+    echo 'Unspecified architecture. Defaulting to x86'
+    docker-compose up -d
 fi
 
 # Runs bot


### PR DESCRIPTION
Tried to run the bot locally and ran into a few issues.
- `start.sh` writes to `./conf/auth.json`, but the code (and .gitignore) seem to expect it to be at the top level.
- `npm install` failed, claiming `0.2` is not a valid version. I believe npm detects valid versions as SemVer (major.minor.patch), so I changed the version to `0.2.0`, and `npm install` worked.
- I am on OSX, so `arch` returns `i386`, which is not a supported architecture, according to start.sh. I was unable to understand why the architecture of the spun-up containers would be based off the host systems architecture (I would imagine running either would work - is that the benefit of using Docker?)
  - I'm looking for feedback on this, because I feel I may be missing a design choice here.